### PR TITLE
Indicate minimum redis version for cluster support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ An asynchronous Redis client for Rust.
 * [Pub/sub](https://redis.io/docs/manual/pubsub/) support
 * [Sentinel](https://redis.io/docs/manual/sentinel/) support
 * [LUA Scripts/Functions](https://redis.io/docs/manual/programmability/) support
-* [Cluster](https://redis.io/docs/manual/scaling/) support
+* [Cluster](https://redis.io/docs/manual/scaling/) support (minimus supported Redis version is 7)
 * [Redis Stack](https://redis.io/docs/stack/) support:
   * [RedisJSON v2.4](https://redis.io/docs/stack/json/) support
   * [RedisSearch v2.6](https://redis.io/docs/stack/search/) support


### PR DESCRIPTION
It is not currently indicated that to implement cluster support [`CLUSTER SHARDS`](https://redis.io/commands/cluster-shards/) is used, which is only available on Redis 7.0 and newer. Not sure if it's intentional final decision, but it's nice to have a clear indication in advance.
Extra question: would PR with support of [`CLUSTER SLOTS`](https://redis.io/commands/cluster-slots/) be possibly accepted to make cluster support works on earlier versions of Redis?