### PR TITLE
Fix deserializing of negative numbers in response to memory stats.

### DIFF
--- a/src/commands/server_commands.rs
+++ b/src/commands/server_commands.rs
@@ -1720,7 +1720,7 @@ pub struct MemoryStats {
 
     #[serde(rename = "allocator-fragmentation.bytes")]
     #[serde(default)]
-    pub allocator_fragmentation_bytes: usize,
+    pub allocator_fragmentation_bytes: isize,
 
     #[serde(rename = "allocator-rss.ratio")]
     #[serde(default)]
@@ -1728,7 +1728,7 @@ pub struct MemoryStats {
 
     #[serde(rename = "allocator-rss.bytes")]
     #[serde(default)]
-    pub allocator_rss_bytes: usize,
+    pub allocator_rss_bytes: isize,
 
     #[serde(rename = "rss-overhead.ratio")]
     #[serde(default)]
@@ -1736,7 +1736,7 @@ pub struct MemoryStats {
 
     #[serde(rename = "rss-overhead.bytes")]
     #[serde(default)]
-    pub rss_overhead_bytes: usize,
+    pub rss_overhead_bytes: isize,
 
     /// See [`INFO`](https://redis.io/commands/info)'s mem_fragmentation_ratio
     #[serde(rename = "fragmentation")]
@@ -1745,7 +1745,7 @@ pub struct MemoryStats {
 
     #[serde(rename = "fragmentation.bytes")]
     #[serde(default)]
-    pub fragmentation_bytes: usize,
+    pub fragmentation_bytes: isize,
 }
 
 /// Sub-result for the [`memory_stats`](ServerCommands::memory_stats) command.


### PR DESCRIPTION
During `cargo test` I've got one test failure which tested response to `memory usage` command.
The failure was due to inability to de-serialize negative integer to `usize` field.
![выява](https://github.com/dahomey-technologies/rustis/assets/385639/65033b1a-412c-4c4c-906d-a98572ca50ea)

I can't find any robust documentation regarding the unsigned/signed types of values in response to `memory usage`. Except that according to [resp 3 specification](https://redis.io/docs/reference/protocol-spec/#resp-integers) the integer values are in range of signed 64-bit integers.

I've found out an existing issue regarding [negative memory](https://github.com/redis/redis/issues/5580) metric which was "fixed"  for specific scenario.

The struct holding memory metrics have some values stored as `size_t` and other as `ssize_t`:
https://github.com/redis/redis/blob/df1890ef7fc0691c0b940f00ddff14a1c395a52a/src/server.h#L1388C16-L1420

But the response is always written by (implicit?) conversion to `long long`:
https://github.com/redis/redis/blob/df1890ef7fc0691c0b940f00ddff14a1c395a52a/src/object.c#L1554-L1656

The computation where subtraction of `size_t` values leading to wrap around is happen here:
https://github.com/redis/redis/blob/df1890ef7fc0691c0b940f00ddff14a1c395a52a/src/object.c#L1172-L1187

So since there are 4 fields where subtraction with wrap around could happen I've decided to preemptively change types  to signed in `rustis`: 3 of them stored in redis code as `ssize_t` and one as `size_t`, but is serialized to negative value anyway.
