### PR TITLE
#28: Enrich network logs with connection tag ([name:]host:port).

### DIFF
--- a/src/network/connection.rs
+++ b/src/network/connection.rs
@@ -83,6 +83,14 @@ impl Connection {
             .await
             .ok_or_else(|| Error::Client("Disconnected by peer".to_owned()))?
     }
+
+    pub(crate) fn tag(&self) -> &str {
+        match self {
+            Connection::Standalone(connection) => connection.tag(),
+            Connection::Sentinel(connection) => connection.tag(),
+            Connection::Cluster(connection) => connection.tag(),
+        }
+    }
 }
 
 impl<'a, R> IntoFuture for PreparedCommand<'a, &'a mut Connection, R>

--- a/src/network/sentinel_connection.rs
+++ b/src/network/sentinel_connection.rs
@@ -128,4 +128,8 @@ impl SentinelConnection {
             )))
         }
     }
+
+    pub(crate) fn tag(&self) -> &str {
+        self.inner_connection.tag()
+    }
 }


### PR DESCRIPTION
During debugging the issue #28 in real application where multiple clients are used I've found it valuable to have network logs annotated with `connection_name`, `host` and `port` to understand the conditions where issue occur. In this MR I'm adding notion of `tag` which is something that is logged in each log message and by default is a combination of `connection_name:host:port` or `host:port`.