### PR TITLE
#28: Added unique sequence to messages and commands to facilitate logs inspection.

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -37,6 +37,7 @@ use std::{
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
     time::Duration,
 };
+use log::trace;
 
 /// Client with a unique connection to a Redis server.
 #[derive(Clone)]
@@ -265,6 +266,7 @@ impl Client {
     #[inline]
     fn send_message(&self, message: Message) -> Result<()> {
         if let Some(msg_sender) = &self.msg_sender as &Option<MsgSender> {
+            trace!("Will enqueue message: {message:?}");
             msg_sender.unbounded_send(message)?;
             Ok(())
         } else {

--- a/src/client/message.rs
+++ b/src/client/message.rs
@@ -2,6 +2,12 @@ use smallvec::SmallVec;
 
 use crate::{resp::Command, PushSender, PubSubSender, RetryReason, network::{ResultSender, ResultsSender}};
 
+#[cfg(debug_assertions)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(debug_assertions)]
+static MESSAGE_SEQUENCE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 #[allow(clippy::large_enum_variant)] 
 #[derive(Debug)]
 pub(crate) enum Commands {
@@ -114,7 +120,10 @@ pub(crate) struct Message {
     pub pub_sub_senders: Option<Vec<(Vec<u8>, PubSubSender)>>,
     pub push_sender: Option<PushSender>,
     pub retry_reasons: Option<SmallVec<[RetryReason; 10]>>,
-    pub retry_on_error: bool
+    pub retry_on_error: bool,
+    #[cfg(debug_assertions)]
+    #[allow(unused)]
+    pub (crate) message_seq: usize,
 }
 
 impl Message {
@@ -126,6 +135,8 @@ impl Message {
             push_sender: None,
             retry_reasons: None,
             retry_on_error,
+            #[cfg(debug_assertions)]
+            message_seq: MESSAGE_SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst),
         }
     }
 
@@ -137,6 +148,8 @@ impl Message {
             push_sender: None,
             retry_reasons: None,
             retry_on_error,
+            #[cfg(debug_assertions)]
+            message_seq: MESSAGE_SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst),
         }
     }
 
@@ -148,6 +161,8 @@ impl Message {
             push_sender: None,
             retry_reasons: None,
             retry_on_error,
+            #[cfg(debug_assertions)]
+            message_seq: MESSAGE_SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst),
         }
     }
 
@@ -163,6 +178,8 @@ impl Message {
             push_sender: None,
             retry_reasons: None,
             retry_on_error: true,
+            #[cfg(debug_assertions)]
+            message_seq: MESSAGE_SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst),
         }
     }
 
@@ -178,6 +195,8 @@ impl Message {
             push_sender: Some(push_sender),
             retry_reasons: None,
             retry_on_error: true,
+            #[cfg(debug_assertions)]
+            message_seq: MESSAGE_SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst),
         }
     }
 
@@ -189,6 +208,8 @@ impl Message {
             push_sender: Some(push_sender),
             retry_reasons: None,
             retry_on_error: false,
+            #[cfg(debug_assertions)]
+            message_seq: MESSAGE_SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst),
         }
     }
 }

--- a/src/network/network_handler.rs
+++ b/src/network/network_handler.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use futures_channel::{mpsc, oneshot};
 use futures_util::{select, FutureExt, SinkExt, StreamExt};
-use log::{debug, error, info, log_enabled, warn, Level};
+use log::{trace, debug, error, info, log_enabled, warn, Level};
 use smallvec::SmallVec;
 use std::collections::{HashMap, VecDeque};
 use tokio::sync::broadcast;
@@ -159,6 +159,7 @@ impl NetworkHandler {
 
         loop {
             if let Some(mut msg) = msg {
+                trace!("[{}] Will handle message: {msg:?}", self.tag);
                 let pub_sub_senders = msg.pub_sub_senders.take();
                 if let Some(pub_sub_senders) = pub_sub_senders {
                     let subscription_type = match &msg.commands {
@@ -476,6 +477,7 @@ impl NetworkHandler {
                                 error!("[{}] Cannot retry message: {e}", self.tag);
                             }
                         } else {
+                            trace!("[{}] Will respond to: {:?}", self.tag, message_to_receive.message);
                             match message_to_receive.message.commands {
                                 Commands::Single(_, Some(result_sender)) => {
                                     if let Err(e) = result_sender.send(result) {

--- a/src/resp/command.rs
+++ b/src/resp/command.rs
@@ -1,5 +1,11 @@
 use crate::resp::{CommandArgs, ToArgs};
 
+#[cfg(debug_assertions)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(debug_assertions)]
+static COMMAND_SEQUENCE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 /// Shortcut function for creating a command.
 #[must_use]
 #[inline(always)]
@@ -21,6 +27,9 @@ pub struct Command {
     #[doc(hidden)]
     #[cfg(debug_assertions)]
     pub kill_connection_on_write: usize,
+    #[cfg(debug_assertions)]
+    #[allow(unused)]
+    pub (crate) command_seq: usize,
 }
 
 impl Command {
@@ -35,6 +44,8 @@ impl Command {
             args: CommandArgs::default(),
             #[cfg(debug_assertions)]
             kill_connection_on_write: 0,
+            #[cfg(debug_assertions)]
+            command_seq: COMMAND_SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst),
         }
     }
 

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -130,5 +130,6 @@ pub fn log_try_init() {
         .filter_level(log::LevelFilter::Debug)
         .target(env_logger::Target::Stdout)
         .is_test(true)
+        .parse_default_env()
         .try_init();
 }


### PR DESCRIPTION
I've found logs to be invaluable source of information when debugging strange timeouts (#28), but I need to know exactly which command & messages are not responded in time. So I propose adding additional fields to `Message` and `Command` structs in debug builds. These fields are easy to grep (thats why they have `message` and `command` in name), sequentially growing and unique across application run. I've also added trace-level logs to catch `Message` being enqueud, handled and responded. Also made it possible to override tests default log level via `RUST_LOG="rustis=trace" cargo test --release -- --nocapture`.
And I'd like to thank you @mcatanzariti for such a great library.