### PR TITLE
#28: Test cluster connection with commands routed to different nodes.

### DIFF
--- a/src/network/cluster_connection.rs
+++ b/src/network/cluster_connection.rs
@@ -426,7 +426,7 @@ impl ClusterConnection {
             self.pending_requests.push_back(request_info);
         } else {
             return Err(Error::Client(format!(
-                "[{}] Cannot send command {} with mistmatched key slots",
+                "[{}] Cannot send command {} with mismatched key slots",
                 self.tag, command_name
             )));
         }

--- a/src/tests/cluster.rs
+++ b/src/tests/cluster.rs
@@ -8,11 +8,15 @@ use crate::{
     },
     network::{Version, ClusterConnection},
     sleep, spawn,
-    tests::get_cluster_test_client,
+    tests::{get_cluster_test_client, get_cluster_test_client_with_command_timeout},
     Error, RedisError, RedisErrorKind, Result,
 };
 use serial_test::serial;
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    future::IntoFuture,
+};
+use futures_util::try_join;
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
@@ -436,5 +440,29 @@ async fn ask() -> Result<()> {
     assert_eq!("value", value);
     client.del("key").await?;
 
+    Ok(())
+}
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[serial]
+async fn commands_to_different_nodes() -> Result<()> {
+    // Assume test cluster has following slots split: [0 - 5460], [5461 - 10922], [10923 - 16383]
+    let client = get_cluster_test_client_with_command_timeout().await?;
+    client.flushall(FlushingMode::Sync).await?;
+
+    client.set("key0", "0").await?; // cluster keyslot key0 = 13252
+    client.set("key1", "1").await?; // cluster keyslot key1 = 9189
+    client.set("key2", "2").await?; // cluster keyslot key2 = 4998
+
+    let (val0, val1, val2) = try_join!(
+        client.get::<_, String>("key0").into_future(),
+        client.get::<_, String>("key1").into_future(),
+        client.get::<_, String>("key2").into_future(),
+    )?;
+
+    assert_eq!("0", val0);
+    assert_eq!("1", val1);
+    assert_eq!("2", val2);
     Ok(())
 }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -117,6 +117,15 @@ pub(crate) async fn get_cluster_test_client() -> Result<Client> {
     .await
 }
 
+pub(crate) async fn get_cluster_test_client_with_command_timeout() -> Result<Client> {
+    log_try_init();
+    let host = get_default_host();
+    Client::connect(format!(
+        "redis+cluster://{host}:7000,{host}:7001,{host}:7002?command_timeout=2000"
+    ))
+    .await
+}
+
 #[cfg(any(feature = "redis-json"))]
 pub(crate) async fn get_redis_stack_test_client() -> Result<Client> {
     log_try_init();


### PR DESCRIPTION
Added test which shows conditions when `ClusterConnection::read` is stuck.
The conditions are the following:
1. `ClusterConnection` sent cmd1 and cmd2 commands to node1 & node2;
2. `ClusterConnection` received responses first from node2 and then from node1;
3. `ClusterConnection::read` is completed with the response to cmd2, but does not respond with result to cmd1 (until event from any of standalone connections, which could never happen no more commands is sent over connection)