### PR TITLE
Support empty FT_SEARCH result

### DIFF
--- a/src/commands/search_commands.rs
+++ b/src/commands/search_commands.rs
@@ -2067,6 +2067,13 @@ impl<'de> Deserialize<'de> for FtSearchResult {
                     return Err(de::Error::custom("sequence `size_hint` is expected for FtSearchResult"));
                 };
 
+                if total_results == 0 {
+                    return Ok(FtSearchResult {
+                        total_results,
+                        results: Vec::new(),
+                    });
+                }
+
                 let row_num_fields = (seq_size - 1) / total_results;
                 let mut results = Vec::with_capacity(total_results);
                 let mut row: Option<FtSearchResultRow> = None;


### PR DESCRIPTION
Currently, ft_search panics with `attempt to subtract with overflow` when the search has no results, and total_results is 0. This PR introduces an explicit check for a total_results value of 0 and returns an empty FtSearchResult in such cases. 