### PR TITLE
Add test to trigger busy-loop on Redis crash.

### DIFF
--- a/redis/cluster.conf
+++ b/redis/cluster.conf
@@ -5,5 +5,6 @@ cluster-node-timeout 5000
 cluster-announce-ip $HOST_IP
 cluster-announce-port $PORT
 cluster-announce-bus-port $BUS_PORT
+enable-debug-command yes
 busy-reply-threshold 500
 appendonly yes

--- a/redis/docker-compose.yml
+++ b/redis/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   redis-standalone:
     image: redis:alpine
     container_name: redis-standalone
+    restart: on-failure:20
     ports:
       - "6379:6379"
     volumes:
@@ -15,6 +16,7 @@ services:
   redis-tls:
     image: docker.io/bitnami/redis
     container_name: redis-tls
+    restart: on-failure:20
     ports:
       - "6380:6379"
     volumes:
@@ -33,6 +35,7 @@ services:
   redis-master:
     image: redis:alpine
     container_name: redis-master
+    restart: on-failure:20
     ports:
       - "6381:6381"
     command: redis-server --port 6381
@@ -40,6 +43,7 @@ services:
   redis-replica:
     image: redis:alpine
     container_name: redis-replica
+    restart: on-failure:20
     ports:
       - "6382:6382"
     command: redis-server --port 6382 --replicaof "${HOST_IP}" 6381 --slave-announce-ip "${HOST_IP}"
@@ -52,6 +56,7 @@ services:
       dockerfile: ./sentinel.dockerfile
     image: redis-sentinel1
     container_name: redis-sentinel1
+    restart: on-failure:20
     ports:
       - "26379:26379"
     depends_on:
@@ -66,6 +71,7 @@ services:
       dockerfile: ./sentinel.dockerfile
     image: redis-sentinel2
     container_name: redis-sentinel2
+    restart: on-failure:20
     ports:
       - "26380:26379"
     depends_on:
@@ -80,6 +86,7 @@ services:
       dockerfile: ./sentinel.dockerfile
     image: redis-sentinel3
     container_name: redis-sentinel3
+    restart: on-failure:20
     ports:
       - "26381:26379"
     depends_on:
@@ -107,6 +114,7 @@ services:
       dockerfile: ./cluster.dockerfile
     image: redis-node1
     container_name: redis-node1
+    restart: on-failure:20
     ports:
       - "7000:7000"
       - "17000:17000"
@@ -121,6 +129,7 @@ services:
       dockerfile: ./cluster.dockerfile
     image: redis-node2
     container_name: redis-node2
+    restart: on-failure:20
     ports:
       - "7001:7001"
       - "17001:17001"
@@ -135,6 +144,7 @@ services:
       dockerfile: ./cluster.dockerfile
     image: redis-node3
     container_name: redis-node3
+    restart: on-failure:20
     ports:
       - "7002:7002"
       - "17002:17002"
@@ -149,6 +159,7 @@ services:
       dockerfile: ./cluster.dockerfile
     image: redis-node4
     container_name: redis-node4
+    restart: on-failure:20
     ports:
       - "7003:7003"
       - "17003:17003"
@@ -163,6 +174,7 @@ services:
       dockerfile: ./cluster.dockerfile
     image: redis-node5
     container_name: redis-node5
+    restart: on-failure:20
     ports:
       - "7004:7004"
       - "17004:17004"
@@ -177,6 +189,7 @@ services:
       dockerfile: ./cluster.dockerfile
     image: redis-node6
     container_name: redis-node6
+    restart: on-failure:20
     ports:
       - "7005:7005"
       - "17005:17005"
@@ -189,5 +202,6 @@ services:
   redis-stack:
     image: redis/redis-stack-server:7.0.6-RC5
     container_name: redis-stack
+    restart: on-failure:20
     ports:
       - "8000:6379"

--- a/redis/docker_up.sh
+++ b/redis/docker_up.sh
@@ -1,2 +1,2 @@
 sh ./set_host_ip.sh
-docker-compose up -d
+docker-compose up -d --build

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use crate::commands::DebugCommands;
 #[cfg(feature = "redis-graph")]
 use crate::commands::GraphCommands;
 #[cfg(feature = "redis-json")]
@@ -19,7 +21,7 @@ use crate::{
         BitmapCommands, BlockingCommands, ClusterCommands, ConnectionCommands, GenericCommands,
         GeoCommands, HashCommands, HyperLogLogCommands, InternalPubSubCommands, ListCommands,
         PubSubCommands, ScriptingCommands, SentinelCommands, ServerCommands, SetCommands,
-        SortedSetCommands, StreamCommands, StringCommands, TransactionCommands,
+        SortedSetCommands, StreamCommands, StringCommands, TransactionCommands
     },
     network::{
         timeout, JoinHandle, MsgSender, NetworkHandler, PubSubReceiver, PubSubSender, PushReceiver,
@@ -427,6 +429,8 @@ impl<'a> CountMinSketchCommands<'a> for &'a Client {}
 #[cfg(feature = "redis-bloom")]
 impl<'a> CuckooCommands<'a> for &'a Client {}
 impl<'a> ConnectionCommands<'a> for &'a Client {}
+#[cfg(test)]
+impl<'a> DebugCommands<'a> for &'a Client {}
 impl<'a> GenericCommands<'a> for &'a Client {}
 impl<'a> GeoCommands<'a> for &'a Client {}
 #[cfg_attr(docsrs, doc(cfg(feature = "redis-graph")))]

--- a/src/commands/debug_commands.rs
+++ b/src/commands/debug_commands.rs
@@ -1,0 +1,76 @@
+use crate::{
+    client::{prepare_command, PreparedCommand},
+    resp::cmd,
+};
+use std::time::Duration;
+
+/// A group of Redis commands related to Debug functionality of redis
+/// # See Also
+/// [Redis Debug Commands](https://redis.io/commands/debug/)
+/// The DEBUG command is an internal command. It is meant to be used
+/// for developing and testing Redis and libraries.
+pub trait DebugCommands<'a> {
+    /// Stop the server for <seconds>. Decimals allowed.
+    #[must_use]
+    fn debug_sleep(self, duration: Duration) -> PreparedCommand<'a, Self, ()>
+    where
+        Self: Sized,
+    {
+        prepare_command(self, cmd("DEBUG").arg("SLEEP").arg(duration.as_secs_f32()))
+    }
+
+    /// Graceful restart: save config, db, restart after a <milliseconds> delay (default 0).
+    #[must_use]
+    fn debug_restart(self, delay: Option<Duration>) -> PreparedCommand<'a, Self, ()>
+    where
+        Self: Sized,
+    {
+        prepare_command(
+            self,
+            cmd("DEBUG")
+                .arg("RESTART")
+                .arg(delay.map(|d| u64::try_from(d.as_millis()).unwrap())),
+        )
+    }
+
+    /// Hard crash and restart after a <milliseconds> delay (default 0).
+    #[must_use]
+    fn debug_crash_and_recover(self, delay: Option<Duration>) -> PreparedCommand<'a, Self, ()>
+    where
+        Self: Sized,
+    {
+        prepare_command(
+            self,
+            cmd("DEBUG")
+                .arg("CRASH-AND-RECOVER")
+                .arg(delay.map(|d| u64::try_from(d.as_millis()).unwrap())),
+        )
+    }
+
+    /// Crash the server by assertion failed.
+    #[must_use]
+    fn debug_assert(self) -> PreparedCommand<'a, Self, ()>
+    where
+        Self: Sized,
+    {
+        prepare_command(self, cmd("DEBUG").arg("ASSERT"))
+    }
+
+    /// Crash the server simulating an out-of-memory error.
+    #[must_use]
+    fn debug_oom(self) -> PreparedCommand<'a, Self, ()>
+    where
+        Self: Sized,
+    {
+        prepare_command(self, cmd("DEBUG").arg("OOM"))
+    }
+
+    /// Crash the server simulating a panic.
+    #[must_use]
+    fn debug_panic(self) -> PreparedCommand<'a, Self, ()>
+    where
+        Self: Sized,
+    {
+        prepare_command(self, cmd("DEBUG").arg("PANIC"))
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -95,6 +95,8 @@ mod count_min_sktech_commands;
 #[cfg_attr(docsrs, doc(cfg(feature = "redis-bloom")))]
 #[cfg(feature = "redis-bloom")]
 mod cuckoo_commands;
+#[cfg(test)]
+mod debug_commands;
 mod generic_commands;
 mod geo_commands;
 #[cfg_attr(docsrs, doc(cfg(feature = "redis-graph")))]
@@ -148,6 +150,8 @@ pub use count_min_sktech_commands::*;
 #[cfg_attr(docsrs, doc(cfg(feature = "redis-bloom")))]
 #[cfg(feature = "redis-bloom")]
 pub use cuckoo_commands::*;
+#[cfg(test)]
+pub use debug_commands::*;
 pub use generic_commands::*;
 pub use geo_commands::*;
 #[cfg_attr(docsrs, doc(cfg(feature = "redis-graph")))]

--- a/src/network/cluster_connection.rs
+++ b/src/network/cluster_connection.rs
@@ -497,6 +497,8 @@ impl ClusterConnection {
                         .position(|sr| sr.node_id == *node_id && sr.result.is_none())?;
                     Some((req_idx, sub_req_idx))
                 }) else {
+                    log::error!("[{}] Received unexpected message: {result:?} from {}",
+                        self.tag, self.nodes[node_idx].connection.tag());
                     return Some(Err(Error::Client(format!(
                         "[{}] Received unexpected message",
                         self.tag

--- a/src/network/standalone_connection.rs
+++ b/src/network/standalone_connection.rs
@@ -164,6 +164,7 @@ impl StandaloneConnection {
             }
             Some(result)
         } else {
+            debug!("[{}] Socked is closed", self.tag);
             None
         }
     }

--- a/src/tests/debug_commands.rs
+++ b/src/tests/debug_commands.rs
@@ -1,0 +1,42 @@
+use crate::{
+    commands::{ConnectionCommands, DebugCommands, PingOptions},
+    tests::{get_cluster_test_client_with_command_timeout, get_test_client},
+    Error, Result,
+};
+use serial_test::serial;
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[serial]
+#[ignore]
+async fn standalone_server_panic() -> Result<()> {
+    let client = get_test_client().await?;
+
+    let panic_result = client.debug_panic().await;
+
+    assert!(matches!(panic_result, Err(_)));
+
+    let ping_result = client.ping::<()>(PingOptions::default()).await;
+
+    assert!(matches!(ping_result, Err(_)));
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[serial]
+#[ignore]
+async fn cluster_server_panic() -> Result<()> {
+    let client = get_cluster_test_client_with_command_timeout().await?;
+
+    let panic_result = client.debug_panic().await;
+
+    assert!(matches!(panic_result, Err(_)));
+
+    let ping_result = client.ping::<()>(PingOptions::default()).await;
+
+    assert!(matches!(ping_result, Err(err) if !matches!(err, Error::Timeout(_))));
+
+    Ok(())
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -41,6 +41,7 @@ mod set_commands;
 mod sorted_set_commands;
 mod stream_commands;
 mod string_commands;
+mod debug_commands;
 #[cfg(feature = "redis-bloom")]
 mod t_disgest_commands;
 #[cfg(feature = "redis-time-series")]


### PR DESCRIPTION
Added test to trigger busy loop when one of the Redis nodes goes down. Tests disabled by default, because they causes Redis to go down.
Currently busy loop is stopped once command timeout exceeded and future is no longer polled, when there is no timeout busy loop is permanent.
This might be helpful to investigate the root-cause of #43.
I also continue investigation the origin of busy loop, but so far the is endless call to `next()` of completed framed TCP stream.