### PR TITLE
Show exec/multi routed to a different nodes.

### DIFF
--- a/src/network/connection.rs
+++ b/src/network/connection.rs
@@ -6,6 +6,7 @@ use crate::{
     StandaloneConnection,
 };
 use serde::de::DeserializeOwned;
+use smallvec::SmallVec;
 use std::future::IntoFuture;
 
 pub enum Connection {
@@ -42,7 +43,7 @@ impl Connection {
     #[inline]
     pub async fn write_batch(
         &mut self,
-        commands: impl Iterator<Item = &mut Command>,
+        commands: SmallVec::<[&mut Command; 10]>,
         retry_reasons: &[RetryReason],
     ) -> Result<()> {
         match self {

--- a/src/network/network_handler.rs
+++ b/src/network/network_handler.rs
@@ -328,7 +328,7 @@ impl NetworkHandler {
 
         if let Err(e) = self
             .connection
-            .write_batch(commands_to_write.into_iter(), &retry_reasons)
+            .write_batch(commands_to_write, &retry_reasons)
             .await
         {
             error!("[{}] Error while writing batch: {e}", self.tag);

--- a/src/network/sentinel_connection.rs
+++ b/src/network/sentinel_connection.rs
@@ -5,6 +5,7 @@ use crate::{
     sleep, Error, Result, RetryReason, StandaloneConnection,
 };
 use log::debug;
+use smallvec::SmallVec;
 
 pub struct SentinelConnection {
     pub inner_connection: StandaloneConnection,
@@ -19,7 +20,7 @@ impl SentinelConnection {
     #[inline]
     pub async fn write_batch(
         &mut self,
-        commands: impl Iterator<Item = &mut Command>,
+        commands: SmallVec::<[&mut Command; 10]>,
         retry_reasons: &[RetryReason],
     ) -> Result<()> {
         self.inner_connection

--- a/src/network/standalone_connection.rs
+++ b/src/network/standalone_connection.rs
@@ -12,6 +12,7 @@ use bytes::BytesMut;
 use futures_util::{SinkExt, StreamExt};
 use log::{debug, log_enabled, Level};
 use serde::de::DeserializeOwned;
+use smallvec::SmallVec;
 use std::future::IntoFuture;
 use tokio::io::AsyncWriteExt;
 use tokio_util::codec::{Encoder, FramedRead, FramedWrite};
@@ -99,7 +100,7 @@ impl StandaloneConnection {
 
     pub async fn write_batch(
         &mut self,
-        commands: impl Iterator<Item = &mut Command>,
+        commands: SmallVec::<[&mut Command; 10]>,
         _retry_reasons: &[RetryReason],
     ) -> Result<()> {
         self.buffer.clear();

--- a/src/tests/pipeline.rs
+++ b/src/tests/pipeline.rs
@@ -2,7 +2,7 @@ use crate::{
     client::BatchPreparedCommand,
     commands::{FlushingMode, ServerCommands, StringCommands},
     resp::{cmd, Value},
-    tests::get_test_client,
+    tests::{get_test_client, get_cluster_test_client},
     Result,
 };
 use serial_test::serial;
@@ -43,6 +43,27 @@ async fn error() -> Result<()> {
 
     let result: Result<(Value, String, String)> = pipeline.execute().await;
     assert!(result.is_err());
+
+    Ok(())
+}
+
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[serial]
+async fn pipeline_on_cluster() -> Result<()> {
+    let client = get_cluster_test_client().await?;
+    client.flushall(FlushingMode::Sync).await?;
+
+    let mut pipeline = client.create_pipeline();
+    pipeline.set("key1", "value1").forget();
+    pipeline.set("key2", "value2").forget();
+    pipeline.get::<_, ()>("key1").queue();
+    pipeline.get::<_, ()>("key2").queue();
+
+    let (value1, value2): (String, String) = pipeline.execute().await?;
+    assert_eq!("value1", value1);
+    assert_eq!("value2", value2);
 
     Ok(())
 }


### PR DESCRIPTION
This test show my naive assumption that transaction with the same-slot keys are correctly routed to particular node. The actual behavior is that `MULTI`, `..commands..` and `EXEC` can be routed to a different nodes leading to obscure response errors.
If transaction commands were routed to the same node redis cluster would handle them as transaction, if for any reason keys in commands batch form different nodes redis will fail `exec`:
```
127.0.0.1:6379> multi
OK
127.0.0.1:6379(TX)> get a
(error) MOVED 15495 10.70.0.12:6379
127.0.0.1:6379(TX)> get b
QUEUED
127.0.0.1:6379(TX)> get c
(error) MOVED 7365 10.70.0.11:6379
127.0.0.1:6379(TX)> get d
(error) MOVED 11298 10.70.0.12:6379
127.0.0.1:6379(TX)> get e
(error) MOVED 15363 10.70.0.12:6379
127.0.0.1:6379(TX)> exec
(error) EXECABORT Transaction discarded because of previous errors.
127.0.0.1:6379>
```
@mcatanzariti  do you think it make sense to add client side validation of keys in transaction batch and fail transaction on client side in case of a key slots are different in transaction batch? Or fix transaction batch routing by picking node by a first key slot in a transaction batch and let redis fail transaction in case of other keys are from a different nodes?

Thanks a lot in advance!