### PR TITLE
Added missing SingleArgCollection for &[T: SingleArg].

### DIFF
--- a/src/resp/to_args.rs
+++ b/src/resp/to_args.rs
@@ -452,6 +452,8 @@ impl SingleArgCollection<Vec<u8>> for CommandArgs {}
 
 impl<T, const N: usize> SingleArgCollection<T> for [T; N] where T: SingleArg {}
 
+impl<T> SingleArgCollection<T> for &[T] where T: SingleArg {}
+
 impl<T> SingleArgCollection<T> for Vec<T> where T: SingleArg {}
 
 impl<A, T> SingleArgCollection<T> for SmallVec<A>
@@ -493,6 +495,13 @@ where
 }
 
 impl<K, V, const N: usize> KeyValueArgsCollection<K, V> for [(K, V); N]
+where
+    K: SingleArg,
+    V: SingleArg,
+{
+}
+
+impl<K, V> KeyValueArgsCollection<K, V> for &[(K, V)]
 where
     K: SingleArg,
     V: SingleArg,

--- a/src/tests/command_args.rs
+++ b/src/tests/command_args.rs
@@ -37,6 +37,11 @@ async fn key_value_collection() -> Result<()> {
     let len = client.hset("key", items).await?;
     assert_eq!(2, len);
 
+    client.del("key").await?;
+    let items = [("field1", "value1"), ("field2", "value2")];
+    let len = client.hset("key", items.as_slice()).await?;
+    assert_eq!(2, len);
+
     client.close().await?;
 
     Ok(())
@@ -56,6 +61,11 @@ async fn set_collection() -> Result<()> {
     client.del("key").await?;
     let items = ["member1", "member2"];
     let len = client.sadd("key", items).await?;
+    assert_eq!(2, len);
+
+    client.del("key").await?;
+    let items = ["member1", "member2"];
+    let len = client.sadd("key", items.as_slice()).await?;
     assert_eq!(2, len);
 
     client.del("key").await?;


### PR DESCRIPTION
Hello @mcatanzariti !

I thinks these trait implementation were actually missing, which prevented slices of custom `SingleArg` implementers being passed directly to functions like `sadd`. Could you please review?

Thanks a lot in advace,
Yury.