### PR TITLE
Fix skip offset calculation in connection info manager

### DIFF
--- a/src/network/command_info_manager.rs
+++ b/src/network/command_info_manager.rs
@@ -118,7 +118,7 @@ impl CommandInfoManager {
                             .iter()
                             .skip(*start_from as usize - 1)
                             .position(|arg| arg.as_slice() == keyword.as_bytes())
-                            .map(|i| i + 1)
+                            .map(|i| i + *start_from as usize)
                     } else {
                         slice
                             .iter()

--- a/src/tests/command_info_manager.rs
+++ b/src/tests/command_info_manager.rs
@@ -2,7 +2,7 @@ use crate::{
     client::IntoConfig,
     commands::{
         GenericCommands, MigrateOptions, SortOptions, SortOrder, SortedSetCommands, StreamCommands,
-        StringCommands, XReadOptions, ZAggregate,
+        StringCommands, XReadGroupOptions, XReadOptions, ZAggregate,
     },
     network::StandaloneConnection,
     tests::{get_default_addr, get_default_host, get_default_port, get_test_client},
@@ -57,6 +57,25 @@ async fn extract_keys() -> Result<()> {
         )
         .await?;
     assert_eq!(2, keys.len());
+    assert_eq!("mystream", keys[0]);
+    assert_eq!("writers", keys[1]);
+
+    // XREADGROUP
+    let keys = command_info_manager
+        .extract_keys(
+            client
+                .xreadgroup::<_, _, _, _, _, _, String, Vec<(_, _)>>(
+                    "mygroup",
+                    "myconsumer",
+                    XReadGroupOptions::default().count(2),
+                    ["mystream", "writers"],
+                    ["1526999352406-0", "1526985685298-0"],
+                )
+                .command(),
+            &mut connection,
+        )
+        .await?;
+    assert_eq!(2, keys.len(), "unexpected keys: {:?}", keys);
     assert_eq!("mystream", keys[0]);
     assert_eq!("writers", keys[1]);
 


### PR DESCRIPTION
This PR adds a test case for a bug that I found (see https://github.com/dahomey-technologies/rustis/issues/61) and a fix for the underlying issue.

The bug is caused by calling skip() and then position() on an iterator without adding the number of skipped elements to the index. It looks like the start_from < 0 case was already handling this, but the >= 0 case wasn't.