### PR TITLE
Don't copy already owned string args.

### DIFF
--- a/src/resp/bulk_string.rs
+++ b/src/resp/bulk_string.rs
@@ -18,6 +18,10 @@ impl BulkString {
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
+
+    pub(crate) fn into_inner(self) -> Vec<u8> {
+        self.0
+    }
 }
 
 impl Deref for BulkString {

--- a/src/resp/command_args.rs
+++ b/src/resp/command_args.rs
@@ -67,8 +67,8 @@ impl CommandArgs {
     }
 
     #[inline]
-    pub(crate) fn write_arg(&mut self, buf: &[u8]) {
-        self.args.push(buf.to_vec());
+    pub(crate) fn write_arg(&mut self, buf: impl Into<Vec<u8>>) {
+        self.args.push(buf.into());
     }
 
     pub(crate) fn retain<F>(&mut self, mut f: F)

--- a/src/resp/to_args.rs
+++ b/src/resp/to_args.rs
@@ -123,7 +123,7 @@ impl ToArgs for bool {
 impl ToArgs for BulkString {
     #[inline]
     fn write_args(&self, args: &mut CommandArgs) {
-        args.write_arg(self.as_bytes());
+        args.write_arg(self.into_inner());
     }
 }
 
@@ -137,7 +137,7 @@ impl ToArgs for Vec<u8> {
 impl ToArgs for &[u8] {
     #[inline]
     fn write_args(&self, args: &mut CommandArgs) {
-        args.write_arg(self);
+        args.write_arg(self.to_vec());
     }
 }
 
@@ -165,7 +165,7 @@ impl ToArgs for &str {
 impl ToArgs for String {
     #[inline]
     fn write_args(&self, args: &mut CommandArgs) {
-        args.write_arg(self.as_bytes());
+        args.write_arg(self.into_bytes());
     }
 }
 


### PR DESCRIPTION
Fixes that when creating Args from `String` and `BulkString` that no unnecessary copy is made.