### PR TITLE
doced example acl_dryrun command

### DIFF
--- a/src/commands/server_commands.rs
+++ b/src/commands/server_commands.rs
@@ -62,14 +62,39 @@ pub trait ServerCommands<'a> {
     /// An error describing why the user can't execute the command.
     ///
     /// # Example
-    /// ```ignore
+    /// ```
+    /// # use rustis::{
+    /// #    client::{Client, ClientPreparedCommand},
+    /// #    commands::{FlushingMode, GetExOptions, GenericCommands, ServerCommands, StringCommands},
+    /// #    resp::cmd,
+    /// #    Result,
+    /// # };
+    /// #
+    /// # #[cfg_attr(feature = "tokio-runtime", tokio::main)]
+    /// # #[cfg_attr(feature = "async-std-runtime", async_std::main)]
+    /// # async fn main() -> Result<()> {
+    /// #     let client = Client::connect("127.0.0.1:6379").await?;
+    /// #     client.flushdb(FlushingMode::Sync).await?;
+    /// #     client.acl_setuser("VIRGINIA", ["+SET", "~*"]).await?;
+    /// let _: () = client
+    ///     .acl_dryrun(
+    ///         "VIRGINIA",
+    ///         "SET",
+    ///         AclDryRunOptions::default().arg("foo").arg("bar"),
+    ///     )
+    ///     .await?;
+    ///
     /// let result: String = client
-    ///    .acl_dryrun("VIRGINIA", "GET", AclDryRunOptions::default().arg("foo"))
-    ///    .await?;
+    ///     .acl_dryrun("VIRGINIA", "GET", AclDryRunOptions::default().arg("foo"))
+    ///     .await?;
+    ///
     /// assert_eq!(
-    ///    "User VIRGINIA has no permissions to run the 'get' command",
-    ///    result
+    ///     "User VIRGINIA has no permissions to run the 'get' command",
+    ///     result
     /// );
+    /// #     client.acl_deluser("VIRGINIA").await?;
+    /// #     Ok(())
+    /// # }
     /// ```
     ///
     /// # See Also

--- a/src/commands/server_commands.rs
+++ b/src/commands/server_commands.rs
@@ -64,8 +64,8 @@ pub trait ServerCommands<'a> {
     /// # Example
     /// ```
     /// # use rustis::{
-    /// #    client::{Client, ClientPreparedCommand},
-    /// #    commands::{FlushingMode, GetExOptions, GenericCommands, ServerCommands, StringCommands},
+    /// #    client::Client,
+    /// #    commands::{ServerCommands, AclDryRunOptions},
     /// #    resp::cmd,
     /// #    Result,
     /// # };
@@ -74,9 +74,8 @@ pub trait ServerCommands<'a> {
     /// # #[cfg_attr(feature = "async-std-runtime", async_std::main)]
     /// # async fn main() -> Result<()> {
     /// #     let client = Client::connect("127.0.0.1:6379").await?;
-    /// #     client.flushdb(FlushingMode::Sync).await?;
     /// #     client.acl_setuser("VIRGINIA", ["+SET", "~*"]).await?;
-    /// let _: () = client
+    /// client
     ///     .acl_dryrun(
     ///         "VIRGINIA",
     ///         "SET",
@@ -85,7 +84,11 @@ pub trait ServerCommands<'a> {
     ///     .await?;
     ///
     /// let result: String = client
-    ///     .acl_dryrun("VIRGINIA", "GET", AclDryRunOptions::default().arg("foo"))
+    ///     .acl_dryrun(
+    ///         "VIRGINIA",
+    ///         "GET",
+    ///         AclDryRunOptions::default().arg("foo")
+    ///     )
     ///     .await?;
     ///
     /// assert_eq!(

--- a/src/commands/server_commands.rs
+++ b/src/commands/server_commands.rs
@@ -62,7 +62,7 @@ pub trait ServerCommands<'a> {
     /// An error describing why the user can't execute the command.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// let result: String = client
     ///    .acl_dryrun("VIRGINIA", "GET", AclDryRunOptions::default().arg("foo"))
     ///    .await?;

--- a/src/commands/server_commands.rs
+++ b/src/commands/server_commands.rs
@@ -61,6 +61,16 @@ pub trait ServerCommands<'a> {
     /// OK on success.
     /// An error describing why the user can't execute the command.
     ///
+    /// # Example
+    /// ```
+    /// let result: String = client.acl_dryrun(
+    ///     "VIRGINIA",
+    ///     "SET",
+    ///     AclDryRunOptions::default().arg("foo").arg("bar"),
+    /// ).await?;
+    /// assert_eq!("Ok", value);
+    /// ```
+    ///
     /// # See Also
     /// [<https://redis.io/commands/acl-dryrun/>](https://redis.io/commands/acl-dryrun/)
     fn acl_dryrun<U, C, R>(

--- a/src/commands/server_commands.rs
+++ b/src/commands/server_commands.rs
@@ -63,12 +63,13 @@ pub trait ServerCommands<'a> {
     ///
     /// # Example
     /// ```
-    /// let result: String = client.acl_dryrun(
-    ///     "VIRGINIA",
-    ///     "SET",
-    ///     AclDryRunOptions::default().arg("foo").arg("bar"),
-    /// ).await?;
-    /// assert_eq!("Ok", value);
+    /// let result: String = client
+    ///    .acl_dryrun("VIRGINIA", "GET", AclDryRunOptions::default().arg("foo"))
+    ///    .await?;
+    /// assert_eq!(
+    ///    "User VIRGINIA has no permissions to run the 'get' command",
+    ///    result
+    /// );
     /// ```
     ///
     /// # See Also


### PR DESCRIPTION
The lsp server(rust-analyzer) will perfectly show an example of this command.