### PR TITLE
add high level client no-touch command

### DIFF
--- a/src/commands/connection_commands.rs
+++ b/src/commands/connection_commands.rs
@@ -208,8 +208,8 @@ pub trait ConnectionCommands<'a> {
     /// # #[cfg_attr(feature = "async-std-runtime", async_std::main)]
     /// # async fn main() -> Result<()> {
     /// #     let client = Client::connect("127.0.0.1:6379").await?;
-    /// let _: () = client.client_no_touch(true).await?;
-    /// let _: () = client.client_no_touch(false).await?;
+    /// client.client_no_touch(true).await?;
+    /// client.client_no_touch(false).await?;
     /// #     Ok(())
     /// }
     /// ```

--- a/src/commands/connection_commands.rs
+++ b/src/commands/connection_commands.rs
@@ -189,6 +189,46 @@ pub trait ConnectionCommands<'a> {
         )
     }
 
+    /// The command controls whether commands sent by the client will alter the LRU/LFU of the keys they access.
+    /// If ON, the client will not change LFU/LRU stats.
+    /// If OFF or send TOUCH, client will change LFU/LRU stats just as a normal client.
+    ///
+    /// # Return
+    /// The () type
+    ///
+    /// # Example
+    /// ```
+    /// # use rustis::{
+    /// #    client::Client,
+    /// #    commands::ConnectionCommands,
+    /// #    Result,
+    /// # };
+    /// #
+    /// # #[cfg_attr(feature = "tokio-runtime", tokio::main)]
+    /// # #[cfg_attr(feature = "async-std-runtime", async_std::main)]
+    /// # async fn main() -> Result<()> {
+    /// #     let client = Client::connect("127.0.0.1:6379").await?;
+    /// let _: () = client.client_no_touch(true).await?;
+    /// let _: () = client.client_no_touch(false).await?;
+    /// #     Ok(())
+    /// }
+    /// ```
+    ///
+    /// # See Also
+    /// [<https://redis.io/docs/latest/commands/client-no-touch/>](https://redis.io/docs/latest/commands/client-no-touch/)
+    #[must_use]
+    fn client_no_touch(self, no_touch: bool) -> PreparedCommand<'a, Self, ()>
+    where
+        Self: Sized,
+    {
+        prepare_command(
+            self,
+            cmd("CLIENT")
+                .arg("NO-TOUCH")
+                .arg(if no_touch { "ON" } else { "OFF" }),
+        )
+    }
+
     /// Connections control command able to suspend all the Redis clients
     /// for the specified amount of time (in milliseconds).
     ///

--- a/src/tests/connection_commands.rs
+++ b/src/tests/connection_commands.rs
@@ -137,8 +137,8 @@ async fn client_list() -> Result<()> {
 async fn client_no_evict() -> Result<()> {
     let client = get_test_client().await?;
 
-    let _: () = client.client_no_evict(true).await?;
-    let _: () = client.client_no_evict(false).await?;
+    client.client_no_evict(true).await?;
+    client.client_no_evict(false).await?;
 
     Ok(())
 }
@@ -149,8 +149,8 @@ async fn client_no_evict() -> Result<()> {
 async fn client_no_touch() -> Result<()> {
     let client = get_test_client().await?;
 
-    let _: () = client.client_no_touch(true).await?;
-    let _: () = client.client_no_touch(false).await?;
+    client.client_no_touch(true).await?;
+    client.client_no_touch(false).await?;
 
     Ok(())
 }

--- a/src/tests/connection_commands.rs
+++ b/src/tests/connection_commands.rs
@@ -137,8 +137,20 @@ async fn client_list() -> Result<()> {
 async fn client_no_evict() -> Result<()> {
     let client = get_test_client().await?;
 
-    client.client_no_evict(true).await?;
-    client.client_no_evict(false).await?;
+    let _: () = client.client_no_evict(true).await?;
+    let _: () = client.client_no_evict(false).await?;
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[serial]
+async fn client_no_touch() -> Result<()> {
+    let client = get_test_client().await?;
+
+    let _: () = client.client_no_touch(true).await?;
+    let _: () = client.client_no_touch(false).await?;
 
     Ok(())
 }


### PR DESCRIPTION
I implement high client no touch command, connection group
https://redis.io/docs/latest/commands/client-no-touch/