### PR TITLE
compile-time lint unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 /*!
 rustis is a Redis client for Rust.


### PR DESCRIPTION
I want to propose a compile-time check of the codebase for unsafe code.
This will provide the library with the guarantees given by standard safe Rust.
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html

Work demonstration
```bash
error: implementation of an `unsafe` method
   --> src/commands/server_commands.rs:864:5
    |
864 | /     unsafe fn memory_help(self) -> PreparedCommand<'a, Self, Vec<String>>
865 | |     where
866 | |         Self: Sized,
867 | |     {
868 | |         prepare_command(self, cmd("MEMORY").arg("HELP"))
869 | |     }
    | |_____^
    |
note: the lint level is defined here
   --> src/lib.rs:1:11
    |
1   | #![forbid(unsafe_code)]
    |           ^^^^^^^^^^^

warning: `rustis` (lib) generated 1 warning
error: could not compile `rustis` (lib) due to 1 previous error;
```