### PR TITLE
third lifetime elision rule

### DIFF
--- a/src/client/pipeline.rs
+++ b/src/client/pipeline.rs
@@ -32,7 +32,7 @@ pub struct Pipeline<'a> {
 }
 
 impl<'a> Pipeline<'a> {
-    pub(crate) fn new(client: &'a Client) -> Pipeline {
+    pub(crate) fn new(client: &Client) -> Pipeline {
         Pipeline {
             client,
             commands: Vec::new(),

--- a/src/commands/string_commands.rs
+++ b/src/commands/string_commands.rs
@@ -109,7 +109,7 @@ pub trait StringCommands<'a> {
     ///     // ... or it can be directly a String.
     ///     // In this cas a `nil` value will result in an empty String
     ///     let value: String = client.get("key").await?;
-    ///     assert_eq!("", &value);
+    ///     assert_eq!("", value);
     ///
     ///     client.set("key", "value").await?;
     ///     let value: String = client.get("key").await?;
@@ -127,7 +127,6 @@ pub trait StringCommands<'a> {
         Self: Sized,
         K: SingleArg,
         V: PrimitiveResponse,
-        Self: Sized,
     {
         prepare_command(self, cmd("GET").arg(key))
     }


### PR DESCRIPTION
Rust will automatically add lifetime annotations
https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html#lifetime-annotations-in-method-definitions
