### PR TITLE
change type for signed numbers in GETRANGE command

### DIFF
--- a/src/commands/string_commands.rs
+++ b/src/commands/string_commands.rs
@@ -207,10 +207,37 @@ pub trait StringCommands<'a> {
     ///
     /// The function handles out of range requests by limiting the resulting range to the actual length of the string.
     ///
+    /// # Example
+    /// ```
+    /// # use rustis::{
+    /// #    client::{Client, ClientPreparedCommand},
+    /// #    commands::{FlushingMode, GetExOptions, GenericCommands, ServerCommands, StringCommands},
+    /// #    resp::cmd,
+    /// #    Result,
+    /// # };
+    ///
+    /// # #[cfg_attr(feature = "tokio-runtime", tokio::main)]
+    /// # #[cfg_attr(feature = "async-std-runtime", async_std::main)]
+    /// # async fn main() -> Result<()> {
+    /// #    let client = Client::connect("127.0.0.1:6379").await?;
+    /// #    client.flushdb(FlushingMode::Sync).await?;
+    /// client.set("mykey", "This is a string").await?;
+    ///
+    /// let value: String = client.getrange("mykey", 0, 5).await?;
+    /// assert_eq!("This", value);
+    /// let value: String = client.getrange("mykey", -3, -1).await?;
+    /// assert_eq!("ing", value);
+    /// let value: String = client.getrange("mykey", 0, -1).await?;
+    /// assert_eq!("This is a string", value);
+    /// let value: String = client.getrange("mykey", 10, 100).await?;
+    /// #    Ok(())
+    /// }
+    /// ```
+    ///
     /// # See Also
     /// [<https://redis.io/commands/getrange/>](https://redis.io/commands/getrange/)
     #[must_use]
-    fn getrange<K, V>(self, key: K, start: usize, end: isize) -> PreparedCommand<'a, Self, V>
+    fn getrange<K, V>(self, key: K, start: isize, end: isize) -> PreparedCommand<'a, Self, V>
     where
         Self: Sized,
         K: SingleArg,

--- a/src/commands/string_commands.rs
+++ b/src/commands/string_commands.rs
@@ -222,7 +222,7 @@ pub trait StringCommands<'a> {
     /// #    client.flushdb(FlushingMode::Sync).await?;
     /// client.set("mykey", "This is a string").await?;
     ///
-    /// let value: String = client.getrange("mykey", 0, 5).await?;
+    /// let value: String = client.getrange("mykey", 0, 3).await?;
     /// assert_eq!("This", value);
     /// let value: String = client.getrange("mykey", -3, -1).await?;
     /// assert_eq!("ing", value);

--- a/src/commands/string_commands.rs
+++ b/src/commands/string_commands.rs
@@ -210,9 +210,8 @@ pub trait StringCommands<'a> {
     /// # Example
     /// ```
     /// # use rustis::{
-    /// #    client::{Client, ClientPreparedCommand},
-    /// #    commands::{FlushingMode, GetExOptions, GenericCommands, ServerCommands, StringCommands},
-    /// #    resp::cmd,
+    /// #    client::Client,
+    /// #    commands::{FlushingMode, StringCommands},
     /// #    Result,
     /// # };
     ///

--- a/src/commands/string_commands.rs
+++ b/src/commands/string_commands.rs
@@ -229,7 +229,7 @@ pub trait StringCommands<'a> {
     /// let value: String = client.getrange("mykey", 0, -1).await?;
     /// assert_eq!("This is a string", value);
     /// let value: String = client.getrange("mykey", 10, 100).await?;
-    /// assert_eq!("string", value)
+    /// assert_eq!("string", value);
     /// #    Ok(())
     /// # }
     /// ```

--- a/src/commands/string_commands.rs
+++ b/src/commands/string_commands.rs
@@ -230,7 +230,7 @@ pub trait StringCommands<'a> {
     /// assert_eq!("This is a string", value);
     /// let value: String = client.getrange("mykey", 10, 100).await?;
     /// #    Ok(())
-    /// }
+    /// # }
     /// ```
     ///
     /// # See Also

--- a/src/commands/string_commands.rs
+++ b/src/commands/string_commands.rs
@@ -211,7 +211,7 @@ pub trait StringCommands<'a> {
     /// ```
     /// # use rustis::{
     /// #    client::Client,
-    /// #    commands::{FlushingMode, StringCommands},
+    /// #    commands::{FlushingMode, ServerCommands, StringCommands},
     /// #    Result,
     /// # };
     ///

--- a/src/commands/string_commands.rs
+++ b/src/commands/string_commands.rs
@@ -229,6 +229,7 @@ pub trait StringCommands<'a> {
     /// let value: String = client.getrange("mykey", 0, -1).await?;
     /// assert_eq!("This is a string", value);
     /// let value: String = client.getrange("mykey", 10, 100).await?;
+    /// assert_eq!("string", value)
     /// #    Ok(())
     /// # }
     /// ```

--- a/src/tests/string_commands.rs
+++ b/src/tests/string_commands.rs
@@ -227,13 +227,16 @@ async fn get_persist() -> Result<()> {
 async fn getrange() -> Result<()> {
     let client = get_test_client().await?;
 
-    client.set("key", "value").await?;
+    client.set("mykey", "This is a string").await?;
 
-    let value: String = client.getrange("key", 1, 3).await?;
-    assert_eq!("alu", value);
-
-    let value: String = client.getrange("key", 1, -3).await?;
-    assert_eq!("al", value);
+    let value: String = client.getrange("mykey", 0, 3).await?;
+    assert_eq!("This", value);
+    let value: String = client.getrange("mykey", -3, -1).await?;
+    assert_eq!("ing", value);
+    let value: String = client.getrange("mykey", 0, -1).await?;
+    assert_eq!("This is a string", value);
+    let value: String = client.getrange("mykey", 10, 100).await?;
+    assert_eq!("string", value);
 
     client.close().await?;
 


### PR DESCRIPTION
func getrange can working with isize type integers
i change type and add tests from doc
```redis
GETRANGE mykey -3 -1
```