### PR TITLE
Remove debug_assertions restrictions for Hash and Hasher

### DIFF
--- a/src/resp/command.rs
+++ b/src/resp/command.rs
@@ -1,9 +1,9 @@
 use crate::resp::{CommandArgs, ToArgs};
+
+use std::hash::{Hash, Hasher};
+
 #[cfg(debug_assertions)]
-use std::{
-    hash::{Hash, Hasher},
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(debug_assertions)]
 static COMMAND_SEQUENCE_COUNTER: AtomicUsize = AtomicUsize::new(0);


### PR DESCRIPTION
Hash and Hasher imports should not be under debug_assertions as it causes issues with --release compilation

     fn hash<H: Hasher>(&self, state: &mut H) {
                ^^^^^^ not found in this scope

     consider importing this trait
     + use std::hash::Hasher
